### PR TITLE
randomize tests and synchronize PRNGs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--order rand

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  srand config.seed
 end


### PR DESCRIPTION
This is less to randomize the tests and more to expose the random seed used by `Faker`; since `Faker` uses `Array#sample`, the source of randomness for `Faker` should be settable via `Kernel#srand`, and since rspec will display its own random seed, we should be able to reproduce failures across environments.