### PR TITLE
destroy related shift_events with shift

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,7 +1,7 @@
 class Shift < ActiveRecord::Base
   belongs_to :work_site
   belongs_to :volunteer
-  has_many   :shift_events
+  has_many   :shift_events, dependent: :destroy
 
   validates :work_site, presence: true
   validates :volunteer, presence: true

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Shift do
+  describe '#destroy' do
+    it 'removes all related ShiftEvents' do
+      shift = FactoryGirl.create(:shift, :full)
+      shift_event_ids = shift.shift_events.map(&:id)
+      shift.destroy
+      expect(ShiftEvent.where(id: shift_event_ids).to_a).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This change is needed to allow admins to delete shifts through the
dashboard.

Fixes #73