### PR TITLE
Add abbreviated signature report on mobile

### DIFF
--- a/app/views/signatures_reports/_desktop_report.html.erb
+++ b/app/views/signatures_reports/_desktop_report.html.erb
@@ -1,0 +1,21 @@
+<table class="hide-on-small-only">
+  <tr>
+    <td>Work Site</td>
+    <td>Day</td>
+    <td>Time</td>
+    <td>Action</td>
+    <td>Volunteer</td>
+    <td class="hide-on-med-and-down">Signature!</td>
+  </tr>
+
+<% @shift_events.each do |event| %>
+  <tr class="entry">
+    <td><%= event.address %></td>
+    <td><%= event.occurred_at.to_date %></td>
+    <td><%= event.occurred_at.strftime("%I:%M%p") %></td>
+    <td><%= event.action %></td>
+    <td><%= event.volunteer_email %></td>
+    <td class="hide-on-med-and-down"><img src='<%= event.signature %>' /></td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/signatures_reports/_mobile_report.html.erb
+++ b/app/views/signatures_reports/_mobile_report.html.erb
@@ -1,0 +1,22 @@
+<div class="hide-on-med-and-up">
+  <p>
+    This is an abbreviated report meant for mobile use.
+    To see full report, please view on desktop.
+  </p>
+  
+  <table>
+    <tr>
+      <td>Work Site</td>
+      <td>Volunteer</td>
+      <td>Action</td>
+    </tr>
+  
+  <% @shift_events.each do |event| %>
+    <tr class="mobile-entry">
+      <td><%= event.address %></td>
+      <td><%= event.volunteer_name %></td>
+      <td><%= event.action %></td>
+    </tr>
+  <% end %>
+  </table>
+</div>

--- a/app/views/signatures_reports/index.html.erb
+++ b/app/views/signatures_reports/index.html.erb
@@ -17,27 +17,8 @@
 <% end %>
 
 <% if @shift_events.any? %>
-  <table>
-    <tr>
-      <td>Work Site</td>
-      <td>Day</td>
-      <td>Time</td>
-      <td>Action</td>
-      <td>Volunteer</td>
-      <td>Signature!</td>
-    </tr>
-
-  <% @shift_events.each do |event| %>
-    <tr class="entry">
-      <td><%= event.address %></td>
-      <td><%= event.occurred_at.to_date %></td>
-      <td><%= event.occurred_at.strftime("%I:%M%p") %></td>
-      <td><%= event.action %></td>
-      <td><%= event.volunteer_email %></td>
-      <td><img src='<%= event.signature %>' /></td>
-    </tr>
-  <% end %>
-  </table>
+  <%= render 'desktop_report' %>
+  <%= render 'mobile_report' %>
 <% else %>
   <h5>No data for this date range</h5>
 <% end %>


### PR DESCRIPTION
Fixes #66

Displays an abbreviated report on mobile with site, volunteer name, and
action for use in the field. Also shows a message informing the user that
the full report is available on desktop.