### PR TITLE
restore the timepicker to the main form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails', '~> 3.0'
   gem 'rubocop'
+  gem 'poltergeist'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -171,6 +172,10 @@ GEM
       ast (~> 2.2)
     pg (0.18.4)
     pkg-config (1.1.7)
+    poltergeist (1.10.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -295,6 +300,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -318,6 +326,7 @@ DEPENDENCIES
   jquery-rails
   materialize-sass
   pg (~> 0.18.4)
+  poltergeist
   pry-doc
   pry-rails
   rails (~> 4.2.6)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,7 +34,7 @@
     // Initialize the datepicker on the sign-in form
     $input = $('#sign_in_form_day').pickadate();
     picker = $input.pickadate('picker');
-    picker.set('select', new Date());
+    if (picker) { picker.set('select', new Date()); }
 
     // Initialize time picker
     $('#pick-a-time').lolliclock({ autoclose:true });

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe 'Checking in at a worksite', type: :feature do
     expect(shift_event.action).to eq('start_shift')
     # expect(shift_event.occurred_at).to eq(Time.zone.local(2016, 1, 1, 16, 30))
   end
+
+  # Given the main form has just loaded
+  # Then I do not see the lolliclock widget
+  scenario 'hides the lolliclock widget when the form loads', js: true do
+    skip 'PhantomJS 2+ required' unless ENV['RAILS_SPEC_JS']
+    visit root_path
+    expect { find(:css, '.lolliclock-popover') }
+      .to raise_error Capybara::ElementNotFound
+  end
+
+  # Given the main form has just loaded
+  # When I click the time input field
+  # Then I see the lolliclock widget
+  scenario 'activates lolliclock when time input is focused', js: true do
+    skip 'PhantomJS 2+ required' unless ENV['RAILS_SPEC_JS']
+    visit root_path
+    page.execute_script('document.getElementById("pick-a-time").click()')
+    clock = find(:css, '.lolliclock-popover')
+    expect(clock).to be_visible
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,8 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   srand config.seed
+
+  # Use PhantomJS to test JavaScript
+  require 'capybara/poltergeist'
+  Capybara.javascript_driver = :poltergeist
 end


### PR DESCRIPTION
Adds some tests, but they won't run under travis at the moment (or anywhere without PhantomJS 2.0+ installed), so I've set them to be skipped with explanation unless an environment variable is set.

I started to write a scenario for the admin view as well, but logging in to a real server isn't compatible with wrapping tests in a transaction, and I'm not sure if we'll need to make enough JS modifications in the future to justify that style of testing.