### PR TITLE
Fix work site deletion

### DIFF
--- a/app/controllers/admin/work_sites_controller.rb
+++ b/app/controllers/admin/work_sites_controller.rb
@@ -15,5 +15,19 @@ module Admin
 
     # See https://administrate-docs.herokuapp.com/customizing_controller_actions
     # for more information
+
+    def activate
+      resource = WorkSite.find params[:work_site_id]
+      resource.activate!
+      flash[:success] = "#{resource.address} successfully activated"
+      redirect_to admin_work_sites_path
+    end
+
+    def deactivate
+      resource = WorkSite.find params[:work_site_id]
+      resource.deactivate!
+      flash[:success] = "#{resource.address} successfully deactivated"
+      redirect_to admin_work_sites_path
+    end
   end
 end

--- a/app/controllers/admin/work_sites_controller.rb
+++ b/app/controllers/admin/work_sites_controller.rb
@@ -20,14 +20,38 @@ module Admin
       resource = WorkSite.find params[:work_site_id]
       resource.activate!
       flash[:success] = "#{resource.address} successfully activated"
-      redirect_to admin_work_sites_path
+      redirect_back fallback_location: admin_work_sites_path
     end
 
     def deactivate
       resource = WorkSite.find params[:work_site_id]
       resource.deactivate!
       flash[:success] = "#{resource.address} successfully deactivated"
-      redirect_to admin_work_sites_path
+      redirect_back fallback_location: admin_work_sites_path
+    end
+
+    private
+
+    ##
+    # Redirects the browser to the page that issued the request (the referrer)
+    # if possible, otherwise redirects to the provided default fallback
+    # location.
+    #
+    # The referrer information is pulled from the HTTP `Referer` (sic) header on
+    # the request. This is an optional header and its presence on the request is
+    # subject to browser security settings and user preferences. If the request
+    # is missing this header, the `fallback_location` will be used.
+    #
+    # Note: This functionality is included in Rails 5, so this method can be
+    #       removed.
+    #
+    def redirect_back(fallback_location: root_url, **args)
+      referer = request.headers['Referer']
+      if referer
+        redirect_to referer, **args
+      else
+        redirect_to fallback_location, **args
+      end
     end
   end
 end

--- a/app/models/work_site.rb
+++ b/app/models/work_site.rb
@@ -1,4 +1,6 @@
 class WorkSite < ActiveRecord::Base
+  has_many :shifts, dependent: :destroy
+
   validates :address, presence: true
 
   scope :active, -> { where active: true }

--- a/app/models/work_site.rb
+++ b/app/models/work_site.rb
@@ -4,4 +4,26 @@ class WorkSite < ActiveRecord::Base
   validates :address, presence: true
 
   scope :active, -> { where active: true }
+
+  def active?
+    !!active
+  end
+
+  def activate
+    self.active = true
+  end
+
+  def activate!
+    activate
+    save!
+  end
+
+  def deactivate
+    self.active = false
+  end
+
+  def deactivate!
+    deactivate
+    save!
+  end
 end

--- a/app/views/admin/work_sites/_collection.html.erb
+++ b/app/views/admin/work_sites/_collection.html.erb
@@ -1,0 +1,89 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table class="collection-data" aria-labelledby="page-title">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label cell-label--<%= attr_type.html_class %>
+          cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        " scope="col">
+        <%= link_to(params.merge(
+          collection_presenter.order_params_for(attr_name)
+        )) do %>
+            <%= attr_name.to_s.titleize %>
+
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <%= svg_tag(
+                  "administrate/sort_arrow.svg",
+                  "sort_arrow",
+                  width: "13",
+                  height: "13"
+                ) %>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <th colspan="2" scope="col"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="table__row"
+          role="link"
+          tabindex="0"
+          data-url="<%= polymorphic_path([namespace, resource]) -%>"
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <%= render_field attribute %>
+          </td>
+        <% end %>
+
+        <td><%= link_to(
+          t("administrate.actions.edit"),
+          [:edit, namespace, resource],
+          class: "action-edit",
+        ) %></td>
+
+        <%# Activate/Deactivate link %>
+
+        <% if resource.active? %>
+          <td><%= link_to(
+            'Deactivate',
+            admin_work_site_activation_path(resource),
+            method: :delete,
+            class: "table__action--destroy",
+          ) %></td>
+        <% else %>
+          <td><%= link_to(
+            'Activate',
+            admin_work_site_activation_path(resource),
+            method: :post,
+            class: "action-edit",
+          ) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/work_sites/index.html.erb
+++ b/app/views/admin/work_sites/index.html.erb
@@ -1,0 +1,60 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<% content_for(:search) do %>
+  <form class="search">
+    <span class="search__icon">
+      <%= svg_tag "administrate/search.svg", "search", width: 16, height: 16 %>
+    </span>
+    <input
+      type="text"
+      name="search"
+      class="search__input"
+      placeholder="Search"
+      value="<%= search_term %>"
+      aria-label="Search"
+    />
+    <span class="search__hint">
+      Press enter to search
+    </span>
+  </form>
+<% end %>
+
+<header class="header">
+  <h1 class="header__heading" id="page-title"><%= content_for(:title) %></h1>
+  <div class="header__actions">
+    <%= link_to(
+      "New #{page.resource_name.titleize.downcase}",
+      [:new, namespace, page.resource_name],
+      class: "button",
+    ) %>
+  </div>
+</header>
+
+<%= render "collection", collection_presenter: page, resources: resources %>
+
+<%= paginate resources %>

--- a/app/views/admin/work_sites/show.html.erb
+++ b/app/views/admin/work_sites/show.html.erb
@@ -1,0 +1,65 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { page.page_title } %>
+
+<header class="header">
+  <h1 class="header__heading"><%= content_for(:title) %></h1>
+  <div class="header__actions">
+    <%= link_to(
+      "Edit",
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) %>
+
+    <%# Activate/Deactivate Button %>
+    <% if page.resource.active? %>
+      <%= link_to(
+        'Deactivate',
+        admin_work_site_activation_path(page.resource),
+        method: :delete,
+        class: "button",
+      ) %>
+    <% else %>
+      <%= link_to(
+        'Activate',
+        admin_work_site_activation_path(page.resource),
+        method: :post,
+        class: "button",
+      ) %>
+    <% end %>
+
+    <%# Destroy Button %>
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      method: :delete,
+      data: { confirm: 'Are you sure? This will irreversibly destroy the work site and all associated shifts.' },
+      class: "button",
+    ) %>
+  </div>
+</header>
+
+<dl>
+  <% page.attributes.each do |attribute| %>
+    <dt class="attribute-label"><%= attribute.name.titleize %></dt>
+
+    <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+        ><%= render_field attribute %></dd>
+  <% end %>
+</dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   authenticate :user do
     namespace :admin do
       resources :users
-      resources :work_sites
+      resources :work_sites do
+        post '/activation', action: :activate
+        delete '/activation', action: :deactivate
+      end
       resources :volunteers
       resources :shifts
       resources :report_recipients

--- a/spec/factories/shift.rb
+++ b/spec/factories/shift.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
   factory :shift do
-    day { Faker::Date.backward(23) }
     work_site
+    
+    sequence :day do |n|
+      Time.zone.today - n.days
+    end
     volunteer { Volunteer.first || FactoryGirl.create(:volunteer) }
 
     trait :full do

--- a/spec/factories/work_site.rb
+++ b/spec/factories/work_site.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :work_site do
     address { "#{Faker::Address.street_address}, #{Faker::Address.city}" }
+    
+    trait :with_shifts do
+      after(:build) do |site|
+        3.times { create(:shift, work_site: site) }
+      end
+    end
   end
 end

--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+##
+# Verify that factories are valid
+#
+FactoryGirl.factories.map(&:name).each do |factory_name|
+  describe "The #{factory_name} factory" do
+    it 'is valid' do
+      subject = build(factory_name)
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/features/edit_work_site_spec.rb
+++ b/spec/features/edit_work_site_spec.rb
@@ -34,38 +34,40 @@ feature 'Admin can edit work sites' do
   end
 
   context 'from the show view' do
-    xscenario 'deactivate work site' do
-      create(:work_site, active: true)
+    scenario 'deactivate work site' do
+      subject = create(:work_site, active: true)
       sign_in_as_admin
       visit admin_work_site_path(subject)
-      click_button 'Deactivate'
+      click_link 'Deactivate'
 
-      expect(current_path).to eq admin_work_sites_path
+      expect(current_path).to eq admin_work_site_path(subject)
+      expect(page).to have_content 'Activate'
       expect(page).not_to have_content 'Deactivate'
       expect(page).to have_content 'successfully deactivated'
       expect(WorkSite.active.any?).to be false
     end
 
-    xscenario 'activate work site' do
-      create(:work_site, active: true)
+    scenario 'activate work site' do
+      subject = create(:work_site, active: false)
       sign_in_as_admin
       visit admin_work_site_path(subject)
-      click_button 'Deactivate'
+      click_link 'Activate'
 
-      expect(current_path).to eq admin_work_sites_path
+      expect(current_path).to eq admin_work_site_path(subject)
+      expect(page).to have_content 'Deactivate'
       expect(page).not_to have_content 'Activate'
       expect(page).to have_content 'successfully activated'
       expect(WorkSite.exists?(active: false)).to be false
     end
 
-    xscenario 'delete work site' do
-      create(:work_site)
+    scenario 'delete work site' do
+      subject = create(:work_site)
       sign_in_as_admin
       visit admin_work_site_path(subject)
-      click_button 'Delete'
+      click_link 'Destroy'
 
       expect(current_path).to eq admin_work_sites_path
-      expect(page).to have_content 'successfully deleted'
+      expect(page).to have_content 'successfully destroyed'
       expect(WorkSite.any?).to be false
     end
   end

--- a/spec/features/edit_work_site_spec.rb
+++ b/spec/features/edit_work_site_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+feature 'Admin can edit work sites' do
+  context 'from the collection view' do
+    # Given I am a signed-in admin on the work site admin index page
+    # When I click "Deactivate" on a collection item
+    # Then the work site is set to inactive
+    scenario 'deactivate work site' do
+      create(:work_site, active: true)
+      sign_in_as_admin
+      visit admin_work_sites_path
+      click_link 'Deactivate'
+
+      expect(current_path).to eq admin_work_sites_path
+      expect(page).not_to have_content 'Deactivate'
+      expect(page).to have_content 'successfully deactivated'
+      expect(WorkSite.active.any?).to be false
+    end
+
+    # Given I am a signed-in admin on the work site admin index page
+    # When I click "Activate" on a collection item
+    # Then the work site is set to active
+    scenario 'activate work site' do
+      create(:work_site, active: false)
+      sign_in_as_admin
+      visit admin_work_sites_path
+      click_link 'Activate'
+
+      expect(current_path).to eq admin_work_sites_path
+      expect(page).not_to have_content 'Activate'
+      expect(page).to have_content 'successfully activated'
+      expect(WorkSite.exists?(active: false)).to be false
+    end
+  end
+
+  context 'from the show view' do
+    xscenario 'deactivate work site' do
+      create(:work_site, active: true)
+      sign_in_as_admin
+      visit admin_work_site_path(subject)
+      click_button 'Deactivate'
+
+      expect(current_path).to eq admin_work_sites_path
+      expect(page).not_to have_content 'Deactivate'
+      expect(page).to have_content 'successfully deactivated'
+      expect(WorkSite.active.any?).to be false
+    end
+
+    xscenario 'activate work site' do
+      create(:work_site, active: true)
+      sign_in_as_admin
+      visit admin_work_site_path(subject)
+      click_button 'Deactivate'
+
+      expect(current_path).to eq admin_work_sites_path
+      expect(page).not_to have_content 'Activate'
+      expect(page).to have_content 'successfully activated'
+      expect(WorkSite.exists?(active: false)).to be false
+    end
+
+    xscenario 'delete work site' do
+      create(:work_site)
+      sign_in_as_admin
+      visit admin_work_site_path(subject)
+      click_button 'Delete'
+
+      expect(current_path).to eq admin_work_sites_path
+      expect(page).to have_content 'successfully deleted'
+      expect(WorkSite.any?).to be false
+    end
+  end
+end

--- a/spec/features/hours_report_spec.rb
+++ b/spec/features/hours_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Admin can download hours report', :feature do
+feature 'Admin can download hours report', type: :feature do
   scenario 'as an admin' do
     sign_in_as_admin
     visit hours_report_path(format: :csv)

--- a/spec/features/root_path_spec.rb
+++ b/spec/features/root_path_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Root path directs user to the appropriate page' do
+feature 'Root path directs user to the appropriate page', type: :feature do
   # Given I am a signed-in user
   # When I visit the root path
   # Then I should see an admin dashboard with a link to the check in form

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Shift do
+RSpec.describe Shift, type: :model do
   describe '#destroy' do
     it 'removes all related ShiftEvents' do
       shift = FactoryGirl.create(:shift, :full)

--- a/spec/models/work_site_spec.rb
+++ b/spec/models/work_site_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe WorkSite, type: :model do
+  describe '#destroy' do
+    it 'deletes a work site record' do
+      create(:work_site).destroy
+      expect(WorkSite.any?).to be false
+    end
+    it 'deletes all associated shifts' do
+      create(:work_site, :with_shifts).destroy
+
+      expect(WorkSite.any?).to be false
+      expect(Shift.any?).to be false
+    end
+  end
+end


### PR DESCRIPTION
Resolves #83 

Tests and implements a fix to #83–deleting a work site now deletes the associated shifts.

**Other changes:** The `:shift` factory now deincrements days instead of choosing a random one (to avoid day/work site collisions), and a factory test was added to ensure factory validity.