### PR TITLE
Add onboarding documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ on an [open issue]–if the relevant issue doesn't exist, open it!
 3. Run `./bin/setup`.
 
 4. Run the tests. We only take pull requests with passing tests, and it's great
-   to know that you have a clean slate: `bundle exec rake` and `bundle exec rubocop`
+   to know that you have a clean slate: `bundle exec rake`
 
 5. Add a test for your change. If you are adding functionality or fixing a
    bug, you should add a test!
@@ -37,5 +37,3 @@ Some things that will increase the chance that your pull request is accepted.
 * Include tests that fail without your code, and pass with it
 * Update the documentation, the surrounding one, examples elsewhere, guides,
   whatever is affected by your contribution
-* The tests and rubocop should both pass–this is required for a successful build!
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+We ♥ contributors! By participating in this project, you agree to abide by the
+Ruby for Good [code of conduct].
+
+[code of conduct]: https://github.com/rubyforgood/code-of-conduct
+
+Here are the basic steps to submit a pull request. Make sure that you're working
+on an [open issue]–if the relevant issue doesn't exist, open it!
+
+[open issue]: https://github.com/rubyforgood/habitat_humanity/issues
+
+1. Fork the repo.
+
+2. Run `./bin/setup`.
+
+3. Run the tests. We only take pull requests with passing tests, and it's great
+   to know that you have a clean slate: `bundle exec rake` and `bundle exec rubocop`
+
+4. Add a test for your change. If you are adding functionality or fixing a
+   bug, you should add a test!
+
+5. Make the test pass.
+
+6. Push to your fork and submit a pull request. Include the issue number
+   (ex. `Resolves #1`) in the PR description.
+
+At this point you're waiting on us–we'll try to respond to your PR quickly.
+We may suggest some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted.
+
+* Use Rails idioms and helpers
+* Include tests that fail without your code, and pass with it
+* Update the documentation, the surrounding one, examples elsewhere, guides,
+  whatever is affected by your contribution
+* The tests and rubocop should both pass–this is required for a successful build!
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,19 +10,22 @@ on an [open issue]–if the relevant issue doesn't exist, open it!
 
 [open issue]: https://github.com/rubyforgood/habitat_humanity/issues
 
-1. Fork the repo.
+1. Claim an issue on [our issue tracker][open issue] by assigning it to yourself
+   (core team member) or commenting. If the issue doesn't exist yet, open it.
 
-2. Run `./bin/setup`.
+2. Fork the repo.
 
-3. Run the tests. We only take pull requests with passing tests, and it's great
+3. Run `./bin/setup`.
+
+4. Run the tests. We only take pull requests with passing tests, and it's great
    to know that you have a clean slate: `bundle exec rake` and `bundle exec rubocop`
 
-4. Add a test for your change. If you are adding functionality or fixing a
+5. Add a test for your change. If you are adding functionality or fixing a
    bug, you should add a test!
 
-5. Make the test pass.
+6. Make the test pass.
 
-6. Push to your fork and submit a pull request. Include the issue number
+7. Push to your fork and submit a pull request. Include the issue number
    (ex. `Resolves #1`) in the PR description.
 
 At this point you're waiting on us–we'll try to respond to your PR quickly.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ To view the admin tools, navigate to `http://localhost:3000/sign_in`. Use the cr
    * Email: `admin@example.com`
    * Password: `password`
 
+*Note: If you didn't run `bin/setup`, run `rake db:initialize_admin` to initialize the admin account.*
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,83 @@
+# New Orleans Area Habitat For Humanity Sign-In
+
 [![Stories in Ready](https://badge.waffle.io/rubyforgood/habitat_humanity.png?label=ready&title=Ready)](https://waffle.io/rubyforgood/habitat_humanity)
+[![Code Climate](https://codeclimate.com/github/rubyforgood/habitat_humanity/badges/gpa.svg)](https://codeclimate.com/github/rubyforgood/habitat_humanity)
 
-New Orleans Area Habitat For Humanity Sign-In
+As software developers we have it pretty good and and housing isn't a concern
+for us. Unfortunately, not everyone is as lucky, especially the people of New
+Orleans. Despite hurricane Katrina happening about a decade ago, there are still
+a lot of displaced people in temporary residences who need somewhere to call
+home. The amazing people at habitat for humanity are trying to fix this with
+their work in New Orleans 9th ward (one of the hardest hit areas by Katrina) and
+with a recent grant they received their work is only going to move quicker. The
+problem is, one of the requirements of the grant is a stricter recording and
+reporting process of their 300 or so daily volunteers which is where we come in!
+Let's help them with the great work they are doing by making this process faster
+so they have more time to rebuilding people's lives.
 
-As software developers we have it pretty good and and housing isn't a concern for us. Unfortunately, not everyone is as lucky, especially the people of New Orleans. Despite hurricane Katrina happening about a decade ago, there are still a lot of displaced people in temporary residences who need somewhere to call home. The amazing people at habitat for humanity are trying to fix this with their work in New Orleans 9th ward (one of the hardest hit areas by Katrina) and with a recent grant they received their work is only going to move quicker. The problem is, one of the requirements of the grant is a stricter recording and reporting process of their 300 or so daily volunteers which is where we come in! Let's help them with the great work they are doing by making this process faster so they have more time to rebuilding people's lives.
+Volunteers will use this app to sign in and out of work sites by entering a
+touch-based signature on their smartphone. The technical details will be decided
+by the team as a group, but this JS widget for taking signatures is promising
+(try it on your phone): https://github.com/szimek/signature_pad
 
-Volunteers will use this app to sign in and out of work sites by entering a touch-based signature on their smartphone. The technical details will be decided by the team as a group, but this JS widget for taking signatures is promising (try it on your phone): https://github.com/szimek/signature_pad
+More information on the organization is available on their website:
+http://www.habitat-nola.org/
 
-More information on the organization is available on their website: http://www.habitat-nola.org/
+
+## Quick Start
+
+By the end of this section, you should have the project and dependencies
+installed on your local system. For information on how to contribute, see
+[Contributing](#contributing).
+
+You need:
+
+- Ruby 2.3
+- Rails 4.2.x
+- Postgres 9.5 (May be changed by team later)
+- PhantomJS (`brew install phantomjs` on macOS or
+  [read instructions][phantom-js-instructions])
+
+[phantom-js-instructions]: (https://github.com/teampoltergeist/poltergeist#installing-phantomjs)
+
+Basically you need Git, Ruby and Rails.  If you have Git, Ruby and Postgres in
+some version or another you're probably set. But:
+
+- If you're working on a virgin Windows machine, you're best off going with
+  the RailsInstaller at http://railsinstaller.org.
+- If you have a virgin Mac OSX machine, just follow the directions in
+  https://gorails.com/setup/osx/10.11-el-capitan.
+
+
+Then from a command prompt:
+
+```bash
+$ git clone http://github.com/rubyforgood/habitat_humanity
+$ cd habitat_humanity
+$ bin/setup
+$ rails s
+```
+
+Then navigate to `http://localhost:3000` in your browser to view the app.
+
+To view the admin tools, navigate to `http://localhost:3000/sign_in`. Use the credentials below:
+
+* Admin
+   * Email: `admin@example.com`
+   * Password: `password`
+
+
+## Contributing
+
+We ♥ contributors! Learn more about our tools, technologies, and workflow
+in the [Wiki][wiki]. Be sure to follow our [Contribution Guidelines][CONTRIBUTING.md]
+before submitting a PR.
+
+To join the conversation, join the [#habitat_humanity][slack-channel] channel
+on Slack ([get an invite][slack-invite]).
+
+[wiki]: https://github.com/rubyforgood/habitat_humanity/wiki
+[CONTRIBUTING.md]: https://github.com/rubyforgood/habitat_humanity/blob/master/CONTRIBUTING.md
+[slack-channel]: https://rubyforgood.slack.com/messages/habitat_humanity
+[slack-invite]: https://rubyforgood.herokuapp.com/
+

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To join the conversation, join the [#habitat_humanity][slack-channel] channel
 on Slack ([get an invite][slack-invite]).
 
 [wiki]: https://github.com/rubyforgood/habitat_humanity/wiki
-[CONTRIBUTING.md]: https://github.com/rubyforgood/habitat_humanity/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: CONTRIBUTING.md
 [slack-channel]: https://rubyforgood.slack.com/messages/habitat_humanity
 [slack-invite]: https://rubyforgood.herokuapp.com/
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: %w(spec spec:rubocop)

--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,7 @@ Dir.chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system 'bin/rake db:setup'
+  system 'bin/rake db:initialize_admin'
 
   puts "\n== Removing old logs and tempfiles =="
   system 'rm -f log/*'


### PR DESCRIPTION
Resolves #92 

Major changes are as follows:
- `bin/setup` now includes admin initialization, so it can be used to set up new downloads
- `README.md` has two new sections:
  - Quick Start is designed to get a new user set up with a working environment and a copy of the repository
  - Contributing points to the guidelines and resources for project contributors
- `CONTRIBUTING.md` lays out our contribution guidelines, from the code of conduct to testing

This PR is parallel to some additions to the project Wiki for details that don't need to be included in the project source code.