### PR TITLE
Fixing Width when admin is signed in

### DIFF
--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -17,7 +17,6 @@ By default, it renders:
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
-  <meta name="viewport" content="initial-scale=1" />
   <title>
     <%= "#{content_for(:title)} | " if content_for(:title).present? %>
     Habitat for Humanity NOLA


### PR DESCRIPTION
Resolves #91

By Removing the meta viewport tag, the entire screen is displayed when an admin is signed in.  This is a quick hack fix to show the entire screen for an admin on mobile.