### PR TITLE
Resolves #97: In setup script, explicitly create tmp directory

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'pathname'
+require 'fileutils'
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
@@ -22,9 +23,10 @@ Dir.chdir APP_ROOT do
   system 'bin/rake db:initialize_admin'
 
   puts "\n== Removing old logs and tempfiles =="
-  system 'rm -f log/*'
-  system 'rm -rf tmp/cache'
+  FileUtils.rm_f 'log/*'
+  FileUtils.rm_rf 'tmp/cache'
 
   puts "\n== Restarting application server =="
-  system 'touch tmp/restart.txt'
+  FileUtils.mkdir('tmp') unless File.directory?('tmp')
+  FileUtils.touch 'tmp/restart.txt'
 end


### PR DESCRIPTION
Use FileUtils for file operations because it's more platform independent than system commands.

Create tmp directory (if it doesn't exist) before creating restart file because on some platforms, touch doesn't create missing parent directories when creating new files.

Resolves #97 