### PR TITLE
Issue 99

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -60,7 +60,7 @@ class Shift < ActiveRecord::Base
   def duration
     duration_without_breaks - breaks_duration
   rescue IncompleteBreakError
-    'Error: incomplete break'
+    'Error: volunteer never checked in from break'
   end
 
   ##

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -47,6 +47,8 @@ class Shift < ActiveRecord::Base
 
   def duration
     duration_without_breaks - breaks_duration
+  rescue IncompleteBreakError
+    'Error: incomplete break'
   end
 
   ##

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -39,6 +39,18 @@ class Shift < ActiveRecord::Base
     started? && ended?
   end
 
+  def self.completed
+    from(from(with_shift_start, :shifts).with_shift_end, :shifts)
+  end
+
+  def self.with_shift_start
+    joins(:shift_events).merge(ShiftEvent.shift_starts)
+  end
+
+  def self.with_shift_end
+    joins(:shift_events).merge(ShiftEvent.shift_ends)
+  end
+
   def duration_without_breaks
     return unless complete?
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -64,8 +64,15 @@ class Shift < ActiveRecord::Base
       .each_slice(2)
   end
 
+  class IncompleteBreakError < StandardError
+    def initialize(message = 'start or end time is missing for a break')
+      super
+    end
+  end
+
   def breaks_duration
     breaks.map do |(start_break, end_break)|
+      raise IncompleteBreakError unless start_break && end_break
       end_break.occurred_at - start_break.occurred_at
     end.inject(0.0, :+).seconds / 1.hour
   end

--- a/app/models/shift_event.rb
+++ b/app/models/shift_event.rb
@@ -15,6 +15,9 @@ class ShiftEvent < ActiveRecord::Base
 
   delegate :address, :day, :volunteer_name, :volunteer_email, :minor, to: :shift
 
+  scope :shift_starts, -> { where(action: 'start_shift') }
+  scope :shift_ends, -> { where(action: 'end_shift') }
+
   def shift_day_matches_occurred_at
     return if day == occurred_at.to_date
     msg = "occurred_at (#{occurred_at.to_date}) does not match day (#{day})"

--- a/app/reports/hours_report.rb
+++ b/app/reports/hours_report.rb
@@ -28,12 +28,11 @@ class HoursReport
   #
   # @return [ActiveRecord::Relation]
   def pull_join
-    # TODO: Have yet to get a Railsy query working here
     Shift
       .includes(:work_site, :volunteer, :shift_events)
+      .completed
       .where(day: begin_date..end_date)
       .order(:day)
-      .select(&:complete?)
   end
 
   ##

--- a/spec/factories/shift.rb
+++ b/spec/factories/shift.rb
@@ -34,6 +34,9 @@ FactoryGirl.define do
       end
     end
 
+    trait :missing_break_return do
+      transient do
+        shift_event_actions(ShiftEvent::ACTIONS.keys - ['end_break'])
       end
     end
   end

--- a/spec/factories/shift.rb
+++ b/spec/factories/shift.rb
@@ -1,25 +1,39 @@
 FactoryGirl.define do
   factory :shift do
     work_site
-    
+
     sequence :day do |n|
       Time.zone.today - n.days
     end
     volunteer { Volunteer.first || FactoryGirl.create(:volunteer) }
 
-    trait :full do
-      after(:build) do |shift|
-        day_begin = shift.day.beginning_of_day
-        day_end = shift.day.end_of_day
-
-        ShiftEvent::ACTIONS.keys.zip(
-          Array.new(4) { Faker::Time.between(day_begin, day_end) }.sort
-        ).each do |(action, occurred_at)|
-          create(
-            :shift_event,
-            action: action, occurred_at: occurred_at, shift: shift,
-          )
+    transient do
+      day_begin { day.beginning_of_day }
+      day_end { day.end_of_day }
+      shift_event_actions []
+      shift_event_actions_with_times do
+        times = Array.new(shift_event_actions.length) do
+          Faker::Time.between(day_begin, day_end)
         end
+        shift_event_actions.zip(times.sort)
+      end
+    end
+
+    after :build do |shift, evaluator|
+      evaluator.shift_event_actions_with_times.each do |(action, occurred_at)|
+        create(
+          :shift_event,
+          action: action, occurred_at: occurred_at, shift: shift,
+        )
+      end
+    end
+
+    trait :full do
+      transient do
+        shift_event_actions ShiftEvent::ACTIONS.keys
+      end
+    end
+
       end
     end
   end

--- a/spec/factories/shift.rb
+++ b/spec/factories/shift.rb
@@ -39,5 +39,11 @@ FactoryGirl.define do
         shift_event_actions(ShiftEvent::ACTIONS.keys - ['end_break'])
       end
     end
+
+    trait :incomplete do
+      transient do
+        shift_event_actions(['start_shift'])
+      end
+    end
   end
 end

--- a/spec/features/hours_report_spec.rb
+++ b/spec/features/hours_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Admin can download hours report', type: :feature do
-  scenario 'as an admin' do
+  scenario 'when all is well' do
     sign_in_as_admin
     visit hours_report_path(format: :csv)
 
@@ -9,5 +9,14 @@ feature 'Admin can download hours report', type: :feature do
 
     expect(page.status_code).to eq 200
     expect(page.response_headers['Content-Type']).to eq 'text/csv'
+  end
+
+  scenario 'when a volunteer forgot to sign back in from a break' do
+    FactoryGirl.create :shift, :missing_break_return, day: Time.zone.yesterday
+    sign_in_as_admin
+
+    visit hours_report_path(format: :csv)
+
+    expect(page.status_code).to eq 200
   end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -9,4 +9,13 @@ RSpec.describe Shift, type: :model do
       expect(ShiftEvent.where(id: shift_event_ids).to_a).to be_empty
     end
   end
+
+  describe '#breaks_duration' do
+    it 'raises an `IncompleteBreakError` if the volunteer forgot to sign back '\
+       'in from their break' do
+      shift = FactoryGirl.create :shift, :missing_break_return
+      expect { shift.breaks_duration }.to raise_error \
+        Shift::IncompleteBreakError
+    end
+  end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Shift, type: :model do
         Shift::IncompleteBreakError
     end
   end
+
+  describe '.completed' do
+    it 'returns only completed shifts' do
+      complete_shift = FactoryGirl.create :shift, :full
+      FactoryGirl.create :shift, :incomplete
+
+      completed_shifts = Shift.completed
+
+      expect(completed_shifts.size).to eq 1
+      expect(completed_shifts).to include complete_shift
+    end
+  end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe Shift, type: :model do
     end
   end
 
+  describe '#duration' do
+    it 'is numeric if the shift has start and end times for each break' do
+      shift = FactoryGirl.create(:shift, :full)
+      expect(shift.duration).to be_a Numeric
+    end
+
+    it 'can handle a missing shift_end event' do
+      shift = FactoryGirl.create :shift, :missing_break_return
+      expect(shift.duration).to eq 'Error: incomplete break'
+    end
+  end
+
   describe '#breaks_duration' do
     it 'raises an `IncompleteBreakError` if the volunteer forgot to sign back '\
        'in from their break' do

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Shift, type: :model do
 
     it 'can handle a missing shift_end event' do
       shift = FactoryGirl.create :shift, :missing_break_return
-      expect(shift.duration).to eq 'Error: incomplete break'
+      expect(shift.duration).to \
+        eq 'Error: volunteer never checked in from break'
     end
   end
 

--- a/spec/reports/hours_report_spec.rb
+++ b/spec/reports/hours_report_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe HoursReport, type: :report do
       FactoryGirl.create :shift, :missing_break_return, day: end_date
       duration_index = HoursReport::JOINED_HEADERS.index(:duration)
       durations = rows.map { |row| row[duration_index] }
-      expect(durations).to include 'Error: incomplete break'
+      expect(durations).to \
+        include 'Error: volunteer never checked in from break'
     end
   end
 end

--- a/spec/reports/hours_report_spec.rb
+++ b/spec/reports/hours_report_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe HoursReport, type: :report do
       .to eq HoursReport::JOINED_HEADERS.size
   end
 
+  it 'includes only completed shifts' do
+    FactoryGirl.create :shift, :full, day: end_date
+    FactoryGirl.create :shift, :incomplete, day: end_date
+    expect(report.pull_join.count).to eq 1
+    expect(report.pull_join).to all be_complete
+  end
+
   describe '#to_csv' do
     before do
       FactoryGirl.create(:work_site, address: '101 Broadway')

--- a/spec/reports/hours_report_spec.rb
+++ b/spec/reports/hours_report_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe HoursReport, type: :report do
   it 'generates CSV' do
     # Create a shift inside our weekly report period
     FactoryGirl.create(:shift, :full, day: begin_date + 1.day)
-    round_trip = CSV.parse(report.to_csv)
-    expect(round_trip.size).to be > 1
-    expect(round_trip.first.size)
+    rows = CSV.parse(report.to_csv)
+    expect(rows.size).to be > 1
+    expect(rows.first.size)
       .to eq HoursReport::JOINED_HEADERS.size
   end
 
@@ -30,12 +30,12 @@ RSpec.describe HoursReport, type: :report do
                          day: begin_date + 1.day,
                          work_site: WorkSite.first)
     end
-    let(:round_trip) { CSV.parse(report.to_csv) }
+    let(:rows) { CSV.parse(report.to_csv) }
 
     it "each row includes a work_site's address" do
       address_index = HoursReport::JOINED_HEADERS
                       .index(:address)
-      addresses = round_trip.map { |r| r[address_index] }
+      addresses = rows.map { |row| row[address_index] }
       addresses.each_with_index do |address, i|
         expect(address)
           .not_to be_blank, "address #{i} blank (#{address.inspect})"
@@ -45,7 +45,7 @@ RSpec.describe HoursReport, type: :report do
     it "each row includes a volunteer's email address" do
       email_index = HoursReport::JOINED_HEADERS
                     .index(:volunteer_email)
-      emails = round_trip.map { |r| r[email_index] }
+      emails = rows.map { |row| row[email_index] }
       emails.each_with_index do |email, i|
         expect(email)
           .not_to be_blank, "email #{i} blank (#{email.inspect})"

--- a/spec/reports/hours_report_spec.rb
+++ b/spec/reports/hours_report_spec.rb
@@ -51,5 +51,12 @@ RSpec.describe HoursReport, type: :report do
           .not_to be_blank, "email #{i} blank (#{email.inspect})"
       end
     end
+
+    it 'reports an error if a volunteer forgot to sign back in from a break' do
+      FactoryGirl.create :shift, :missing_break_return, day: end_date
+      duration_index = HoursReport::JOINED_HEADERS.index(:duration)
+      durations = rows.map { |row| row[duration_index] }
+      expect(durations).to include 'Error: incomplete break'
+    end
   end
 end

--- a/spec/reports/signatures_report_spec.rb
+++ b/spec/reports/signatures_report_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe SignaturesReport, type: :report do
 
     # Create a shift inside our weekly report period
     FactoryGirl.create(:shift, :full, day: begin_date + 1.day)
-    round_trip = CSV.parse(report.to_csv)
-    expect(round_trip.size).to be > 1
-    expect(round_trip.first.size)
+    rows = CSV.parse(report.to_csv)
+    expect(rows.size).to be > 1
+    expect(rows.first.size)
       .to eq SignaturesReport::JOINED_HEADERS.size
   end
 
@@ -33,12 +33,12 @@ RSpec.describe SignaturesReport, type: :report do
                          day: begin_date + 1.day,
                          work_site: WorkSite.first)
     end
-    let(:round_trip) { CSV.parse(report.to_csv) }
+    let(:rows) { CSV.parse(report.to_csv) }
 
     it "each row includes a work_site's address" do
       address_index = SignaturesReport::JOINED_HEADERS
                       .index(:address)
-      addresses = round_trip.map { |r| r[address_index] }
+      addresses = rows.map { |row| row[address_index] }
       addresses.each_with_index do |address, i|
         expect(address)
           .not_to be_blank, "address #{i} blank (#{address.inspect})"
@@ -48,7 +48,7 @@ RSpec.describe SignaturesReport, type: :report do
     it "each row includes a volunteer's email address" do
       email_index = SignaturesReport::JOINED_HEADERS
                     .index(:volunteer_email)
-      emails = round_trip.map { |r| r[email_index] }
+      emails = rows.map { |row| row[email_index] }
       emails.each_with_index do |email, i|
         expect(email)
           .not_to be_blank, "email #{i} blank (#{email.inspect})"


### PR DESCRIPTION
Resolve #99

If a volunteer forgets to sign back in from a break, detect this when generating the hours report, and include an error message in the corresponding cell in the shift duration column (telling them we couldn't calculate the duration because there was incomplete information).

When I was reviewing the code for `HoursReport`, I noticed that the `pull_join` method could be cleaned up a little, so I went ahead and did that too (I wrote a spec to make sure I didn't change behavior). If you guys don't want it in this pull request, I can remove it from this branch.

I also want to display a flash message telling the admin to take a closer look at the report if we detect that there is missing info, but I'm not exactly sure how to go about doing that (or if it's even possible). I just wanted to make it obvious to the admin that spreadsheet was incomplete so that they didn't accidentally miss the error message in the spreadsheet.