### PR TITLE
Prepare test db in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -21,6 +21,7 @@ Dir.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system 'bin/rake db:setup'
   system 'bin/rake db:initialize_admin'
+  system 'bin/rake db:test:prepare'
 
   puts "\n== Removing old logs and tempfiles =="
   FileUtils.rm_f 'log/*'


### PR DESCRIPTION
Resolves #105

This adds `db:test:prepare` to our setup script to make sure that our test database is ready to go. This will check if there are any pending migrations and load the test schema from `db/schema.rb`.