### PR TITLE
Resolves #113: Add volunteer name to desktop signature report

### DIFF
--- a/app/views/signatures_reports/_desktop_report.html.erb
+++ b/app/views/signatures_reports/_desktop_report.html.erb
@@ -4,7 +4,8 @@
     <td>Day</td>
     <td>Time</td>
     <td>Action</td>
-    <td>Volunteer</td>
+    <td>Volunteer Name</td>
+    <td>Volunteer Email</td>
     <td class="hide-on-med-and-down">Signature!</td>
   </tr>
 
@@ -14,6 +15,7 @@
     <td><%= event.occurred_at.to_date %></td>
     <td><%= event.occurred_at.strftime("%I:%M%p") %></td>
     <td><%= event.action %></td>
+    <td><%= event.volunteer_name %></td>
     <td><%= event.volunteer_email %></td>
     <td class="hide-on-med-and-down"><img src='<%= event.signature %>' /></td>
   </tr>

--- a/spec/features/signature_report_spec.rb
+++ b/spec/features/signature_report_spec.rb
@@ -19,6 +19,27 @@ feature 'Admins can view the volunteer signature report', type: :feature do
   end
 
   # Given I am a signed-in site admin
+  # When I visit the volunteer signature report page
+  # Then I see a list of information on shift events
+  scenario 'when an admin sees shift information' do
+    generate_entries dates: [Time.zone.today]
+    shift_event = ShiftEvent.last
+
+    sign_in_as_admin
+    visit signatures_report_path
+
+    within('.entry') do
+      expect(page).to have_content(shift_event.address)
+      expect(page).to have_content(shift_event.occurred_at.to_date)
+      expect(page).to have_content(shift_event.occurred_at.strftime('%I:%M%p'))
+      expect(page).to have_content(shift_event.action)
+      expect(page).to have_content(shift_event.volunteer_name)
+      expect(page).to have_content(shift_event.volunteer_email)
+      expect(page).to have_css('img')
+    end
+  end
+
+  # Given I am a signed-in site admin
   # When I set the start and end dates to valid values
   # Then I see a list of volunteer actions for the given date range
   scenario 'when the start and end dates are specified' do


### PR DESCRIPTION
Resolves #113 
Adds the volunteer's name in front of the volunteer's email on the desktop signature report.

Created a new test for the signature report that verifies all the shift event information is present.