### PR TITLE
add custom view that allows for datetime in the shift_events index

### DIFF
--- a/app/views/admin/shift_events/_collection.html.erb
+++ b/app/views/admin/shift_events/_collection.html.erb
@@ -1,0 +1,83 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table class="collection-data" aria-labelledby="page-title">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label cell-label--<%= attr_type.html_class %>
+          cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        " scope="col">
+        <%= link_to(params.merge(
+          collection_presenter.order_params_for(attr_name)
+        )) do %>
+            <%= attr_name.to_s.titleize %>
+
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <%= svg_tag(
+                  "administrate/sort_arrow.svg",
+                  "sort_arrow",
+                  width: "13",
+                  height: "13"
+                ) %>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <th colspan="2" scope="col"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="table__row"
+          role="link"
+          tabindex="0"
+          data-url="<%= polymorphic_path([namespace, resource]) -%>"
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if attribute.class == Administrate::Field::DateTime %>
+              <%= attribute.data.to_datetime.strftime('%F %R %z %a') %>
+            <% else %>
+              <%= render_field attribute %>
+            <% end %>
+          </td>
+        <% end %>
+
+        <td><%= link_to(
+          t("administrate.actions.edit"),
+          [:edit, namespace, resource],
+          class: "action-edit",
+        ) %></td>
+
+        <td><%= link_to(
+          t("administrate.actions.destroy"),
+          [namespace, resource],
+          class: "table__action--destroy",
+          method: :delete,
+          data: { confirm: t("administrate.actions.confirm") }
+        ) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
Resolves #114 

The way the Administrate gem renders `DateTime` objects by default is as `Date`s.

[source](https://github.com/thoughtbot/administrate/blob/master/app/views/fields/date_time/_index.html.erb)

I referenced the [Administrate docs](http://administrate-prototype.herokuapp.com/customizing_page_views) to auto-generate a custom view, and modified the partial on lines 59-63 to override that default behavior for `DateTime`s. The formatting can be altered on line 62 as desired. 