### PR TITLE
fix time zone conversion on form submission

### DIFF
--- a/app/forms/check_in_form.rb
+++ b/app/forms/check_in_form.rb
@@ -1,7 +1,7 @@
 class CheckInForm < ApplicationForm
   DATE_FORMAT     = '%d %B, %Y'.freeze
   TIME_FORMAT     = '%l:%M %p'.freeze
-  COMBINED_FORMAT = "#{DATE_FORMAT} #{TIME_FORMAT}".freeze
+  COMBINED_FORMAT = "#{DATE_FORMAT} #{TIME_FORMAT} %z".freeze
   SHIFT_ACTIONS   = %w(start_shift end_shift).freeze
 
   attr_accessor :name, :email, :work_site_id, :day, :time, :action, :signature,
@@ -49,7 +49,11 @@ class CheckInForm < ApplicationForm
   end
 
   def occurred_at
-    Time.strptime "#{day} #{time}", COMBINED_FORMAT
+    time_zone_offset =
+      ActiveSupport::TimeZone[Rails.application.config.time_zone]
+      .formatted_offset
+
+    Time.strptime "#{day} #{time} #{time_zone_offset}", COMBINED_FORMAT
   end
 
   def shift

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Checking in at a worksite', type: :feature do
 
     shift_event = ShiftEvent.first
     expect(shift_event.action).to eq('start_shift')
-    # expect(shift_event.occurred_at).to eq(Time.zone.local(2016, 1, 1, 16, 30))
+    expect(shift_event.occurred_at).to eq(Time.zone.local(2016, 1, 1, 16, 30))
   end
 
   # Given the main form has just loaded


### PR DESCRIPTION
On insertion to the database, times were built as UTC when they were supposed to
be US Central time. We had an assertion to test this, but it was disabled.