### PR TITLE
Resolves #98: updates readme to start server with puma command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then from a command prompt:
 $ git clone http://github.com/rubyforgood/habitat_humanity
 $ cd habitat_humanity
 $ bin/setup
-$ rails s
+$ puma
 ```
 
 Then navigate to `http://localhost:3000` in your browser to view the app.


### PR DESCRIPTION
After reading through the issue description, I updated the readme to use `puma` to start the rails server. I then took a brief look through the wiki and didn't see any locations where this would need to be updated. I hope this satisfies the requirements! 

Let me know if there is any recommended changes. 