### PR TITLE
Issue 4 - validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'reform', '~> 2.1.0'
 gem 'sass-rails', '~> 5.0'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+gem 'validates_timeliness'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,7 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.5)
     timecop (0.8.1)
+    timeliness (0.3.8)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -301,6 +302,8 @@ GEM
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.0.5)
+    validates_timeliness (4.0.2)
+      timeliness (~> 0.3.7)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -353,6 +356,7 @@ DEPENDENCIES
   timecop (~> 0.8.1)
   turbolinks
   uglifier (>= 1.3.0)
+  validates_timeliness
   web-console (~> 2.0)
 
 RUBY VERSION

--- a/app/forms/check_in_form.rb
+++ b/app/forms/check_in_form.rb
@@ -11,7 +11,8 @@ class CheckInForm < ApplicationForm
   validates :email,     presence: true
   validates :work_site, presence: true
   validates :day,       presence: true
-  validates :time,      presence: true
+  validates :time,      presence: true,
+                        timeliness: { between: '7:00am'..'5:00pm' }
   validates :action,    presence: true
   validates :signature, presence: true, if: :signature_required?
 

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,0 +1,40 @@
+ValidatesTimeliness.setup do |config|
+  # Extend ORM/ODMs for full support (:active_record included).
+  config.extend_orms = [:active_record]
+  #
+  # Default timezone
+  # config.default_timezone = :utc
+  #
+  # Set the dummy date part for a time type values.
+  # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
+  #
+  # Ignore errors when restriction options are evaluated
+  # config.ignore_restriction_errors = false
+  #
+  # Re-display invalid values in date/time selects
+  # config.enable_date_time_select_extension!
+  #
+  # Handle multiparameter date/time values strictly
+  # config.enable_multiparameter_extension!
+  #
+  # Shorthand date and time symbols for restrictions
+  # config.restriction_shorthand_symbols.update(
+  #   :now   => lambda { Time.current },
+  #   :today => lambda { Date.current }
+  # )
+  #
+  # Use the plugin date/time parser which is stricter and extendable
+  # config.use_plugin_parser = false
+  #
+  # Add one or more formats making them valid. e.g. add_formats(:date, 'd(st|rd|th) of mmm, yyyy')
+  # config.parser.add_formats()
+  #
+  # Remove one or more formats making them invalid. e.g. remove_formats(:date, 'dd/mm/yyy')
+  # config.parser.remove_formats()
+  #
+  # Change the ambiguous year threshold when parsing a 2 digit year
+  # config.parser.ambiguous_year_threshold =  30
+  #
+  # Treat ambiguous dates, such as 01/02/1950, as a Non-US date.
+  # config.parser.remove_us_formats
+end

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,0 +1,16 @@
+en:
+  errors:
+    messages:
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -40,4 +40,20 @@ feature 'Checking in at a worksite', type: :feature do
     clock = find '.lolliclock-popover'
     expect(clock).to be_visible
   end
+
+  scenario 'gives an error if the user tries to check in too early' do
+    work_site = create :work_site
+
+    visit root_path
+    fill_in 'Name', with: 'Sam Jones'
+    fill_in 'Email', with: 'my@email.com'
+    select work_site.address, from: 'Work site'
+    fill_in 'Day', with: '1 January, 2016'
+    fill_in 'pick-a-time', with: '1:00 AM'
+    select 'Start Shift', from: 'Action'
+    find('#check_in_form_signature', visible: false).set 'my signature'
+    click_button 'Save'
+
+    expect(page).to have_content 'not valid'
+  end
 end

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe 'Checking in at a worksite', type: :feature do
-  it 'saves the shift event' do
+feature 'Checking in at a worksite', type: :feature do
+  scenario 'saves the shift event' do
     work_site = create :work_site
 
     visit root_path

--- a/spec/forms/check_in_form_spec.rb
+++ b/spec/forms/check_in_form_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe CheckInForm do
     end
   end
 
+  describe 'time field' do
+    it 'is required to be between 7am and 5pm' do
+      form = build :check_in_form, time: '1:00 AM'
+
+      expect(form).to be_invalid
+      expect(form.errors[:time]).to_not be_blank
+    end
+  end
+
   describe '#save' do
     context 'when the volunteer signs in for the start of the shift' do
       let(:form) { build :check_in_form, action: 'start_shift' }

--- a/spec/forms/check_in_form_spec.rb
+++ b/spec/forms/check_in_form_spec.rb
@@ -30,11 +30,17 @@ RSpec.describe CheckInForm do
   end
 
   describe 'time field' do
-    it 'is required to be between 7am and 5pm' do
+    it 'is invalid when not between 7am and 5pm' do
       form = build :check_in_form, time: '1:00 AM'
 
       expect(form).to be_invalid
       expect(form.errors[:time]).to_not be_blank
+    end
+
+    it 'is valid when between 7am and 5pm' do
+      form = build :check_in_form, time: '8:00am'
+
+      expect(form).to be_valid
     end
   end
 


### PR DESCRIPTION
This PR adds in server side validation for the time attribute of the check in form. For now, it is just fixed at 7am - 5pm, but the next PR will enable admins to configure this. Or I can add it to this PR if you want.

This is part of the solution to issue #4.