### PR TITLE
enable phantomjs-based specs in CI

### DIFF
--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -5,6 +5,13 @@ require 'rails_helper'
 #
 FactoryGirl.factories.map(&:name).each do |factory_name|
   describe "The #{factory_name} factory" do
+    around do |example|
+      time = Timeliness.parse('2017-01-01 10:00am', zone: 'US/Central')
+      Timecop.freeze(time) do
+        example.run
+      end
+    end
+
     it 'is valid' do
       subject = build(factory_name)
       expect(subject).to be_valid

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -20,8 +20,6 @@ feature 'Checking in at a worksite', type: :feature do
   # Given the main form has just loaded
   # Then I do not see the lolliclock widget
   scenario 'hides the lolliclock widget when the form loads', js: true do
-    skip 'PhantomJS 2+ required' unless ENV['RAILS_SPEC_JS']
-
     visit root_path
 
     expect { find '.lolliclock-popover' }
@@ -32,8 +30,6 @@ feature 'Checking in at a worksite', type: :feature do
   # When I click the time input field
   # Then I see the lolliclock widget
   scenario 'activates lolliclock when time input is focused', js: true do
-    skip 'PhantomJS 2+ required' unless ENV['RAILS_SPEC_JS']
-
     visit root_path
     page.execute_script('document.getElementById("pick-a-time").click()')
 

--- a/spec/features/signature_report_spec.rb
+++ b/spec/features/signature_report_spec.rb
@@ -156,7 +156,6 @@ feature 'Admins can view the volunteer signature report', type: :feature do
   end
 
   scenario 'when an admin visits the page', js: true do
-    skip 'PhantomJS 2+ required' unless ENV['RAILS_SPEC_JS']
     generate_entries dates: [Time.zone.today]
 
     visit new_user_session_path

--- a/spec/forms/check_in_form_spec.rb
+++ b/spec/forms/check_in_form_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe CheckInForm do
   describe 'signature field' do
+    around do |example|
+      time = Timeliness.parse('2017-01-01 10:00am', zone: 'US/Central')
+      Timecop.freeze(time) do
+        example.run
+      end
+    end
+
     it 'is required for start_shift' do
       form = build :check_in_form, signature: nil, action: 'start_shift'
 
@@ -45,6 +52,13 @@ RSpec.describe CheckInForm do
   end
 
   describe '#save' do
+    around do |example|
+      time = Timeliness.parse('2017-01-01 10:00am', zone: 'US/Central')
+      Timecop.freeze(time) do
+        example.run
+      end
+    end
+
     context 'when the volunteer signs in for the start of the shift' do
       let(:form) { build :check_in_form, action: 'start_shift' }
 


### PR DESCRIPTION
Resolves #133 

It looks like adding the `phantomjs` gem (https://github.com/rubyforgood/habitat_humanity/commit/e004a4a0a94d95fee0985fd2977d607bd4c528f9) gave us a suitable PhantomJS installation for CI purposes, so we could have removed these skips any time after that.